### PR TITLE
Update AKS action for use with AKS AAD auth/RBAC and other ACR.

### DIFF
--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -18,13 +18,14 @@ jobs:
           with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
         
-        - name: 'Build image'
+        - name: 'Log in Docker'
           uses: azure/docker-login@v1
           with:
             login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
             username: ${{ secrets.REGISTRY_USERNAME }}
             password: ${{ secrets.REGISTRY_PASSWORD }}
-        - run: |
+        - name: 'Build Image'
+          run: |
             docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pythonserver:${{ github.sha }}
         - name: Prisma Cloud image scan
           id: scan

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -59,6 +59,9 @@ jobs:
         - name: Setup kubectl
           id: install-kubectl
           uses: azure/setup-kubectl@v3
+        - name: Update Registry URL
+          run: |
+            sed -i.bak 's/pcgithub.azurecr.io/${{ secrets.REGISTRY_LOGIN_SERVER }}/' aks-deployment.yml
         - name: Deploy to AKS
           id: deploy-aks
           uses: Azure/k8s-deploy@v4

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -70,4 +70,4 @@ jobs:
             manifests: |
               aks-deployment.yml
             images: '${{ secrets.REGISTRY_LOGIN_SERVER }}/pythonserver:${{ github.sha }}'
-            
+            annotate-namespace: 'false'

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -35,12 +35,7 @@ jobs:
             pcc_pass: ${{ secrets.PCC_PASS }}
             image_name: ${{ secrets.REGISTRY_LOGIN_SERVER }}/pythonserver:${{ github.sha }}
         - name: 'Push image'
-          uses: azure/docker-login@v1
-          with:
-            login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            username: ${{ secrets.REGISTRY_USERNAME }}
-            password: ${{ secrets.REGISTRY_PASSWORD }}
-        - run: |
+          run: |
             docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/pythonserver:${{ github.sha }}
         - name: Set up kubelogin for non-interactive login
           run: |

--- a/.github/workflows/aks.yml
+++ b/.github/workflows/aks.yml
@@ -42,12 +42,20 @@ jobs:
             password: ${{ secrets.REGISTRY_PASSWORD }}
         - run: |
             docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/pythonserver:${{ github.sha }}
+        - name: Set up kubelogin for non-interactive login
+          run: |
+            curl -LO https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
+            sudo unzip -j kubelogin-linux-amd64.zip -d /usr/local/bin
+            rm -f kubelogin-linux-amd64.zip
+            kubelogin --version
         - name: Set AKS context
           id: set-context
           uses: azure/aks-set-context@v3
           with:
             resource-group: '${{ secrets.resource_group }}' 
             cluster-name: '${{ secrets.cluster_name }}'
+            admin: 'false'
+            use-kubelogin: 'true'
         - name: Setup kubectl
           id: install-kubectl
           uses: azure/setup-kubectl@v3


### PR DESCRIPTION
**WARNING**: This is a somewhat big and potentially breaking update.

As discussed in #63 I've made changes to support AKS AAD auth/RBAC. Is one switches from the original to AAD integrated RBAC, I expect that k8s integration should continue working, but ACR user and password need to be changed to `clientId`/`clientSecret` as used in Azure CLI login.

Next to some minor changes, I've also added a simple `sed` step to edit the ACR URL in the deployment yaml to the one from the variable. This is necessary if the original ACR is not used.

As in #63, please try to test the changes before merging into main if at all possible, and let me know if there are any issues.